### PR TITLE
Avoid crash when validate empty string

### DIFF
--- a/framework/uicomponents/view/validators/doubleinputvalidator.cpp
+++ b/framework/uicomponents/view/validators/doubleinputvalidator.cpp
@@ -53,6 +53,11 @@ void DoubleInputValidator::fixup(QString& string) const
         }
     };
 
+    if (string.isEmpty()) {
+        string.append("0");
+        return;
+    }
+
     if (string.startsWith(".")) {
         string.prepend("0");
     }


### PR DESCRIPTION
Avoid doubleInputValidator to crash on empty strings.