### PR TITLE
Avoid crash on validator when string is empty

### DIFF
--- a/framework/uicomponents/view/validators/doubleinputvalidator.cpp
+++ b/framework/uicomponents/view/validators/doubleinputvalidator.cpp
@@ -53,6 +53,10 @@ void DoubleInputValidator::fixup(QString& string) const
         }
     };
 
+    if (string.isEmpty()) {
+        string.append("0");
+    }
+
     if (string.startsWith(".")) {
         string.prepend("0");
     }


### PR DESCRIPTION
I have seen some crashs due the validator trying to process an empty string.
This will fix it setting a default value.