### PR TITLE
Popup menu on top

### DIFF
--- a/framework/uicomponents/qml/Muse/UiComponents/ContextMenuLoader.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/ContextMenuLoader.qml
@@ -60,6 +60,12 @@ Item {
     StyledMenuLoader {
         id: contextMenuLoader
 
+        onMenuChanged: {
+            if (menu) {
+                menu.setParentWindow(root.Window.window)
+            }
+        }
+
         onHandleMenuItem: function(itemId) {
             container.handleMenuItem(itemId)
         }

--- a/framework/uicomponents/qml/Muse/UiComponents/StyledMenuLoader.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/StyledMenuLoader.qml
@@ -33,6 +33,7 @@ Loader {
     signal openNextMenu()
     signal opened()
     signal closed(bool force)
+    signal menuLoaded()
 
     property StyledMenu menu: loader.item as StyledMenu
     property Item menuAnchorItem: null
@@ -41,6 +42,12 @@ Loader {
     property alias isMenuOpened: loader.active
 
     property string accessibleName: ""
+
+    onMenuChanged: {
+        if (menu) {
+            loader.menuLoaded()
+        }
+    }
 
     QtObject {
         id: prv

--- a/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
+++ b/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
@@ -197,6 +197,10 @@ MenuView {
             root.subMenuLoader.menuAnchorItem = root.anchorItem
             root.subMenuLoader.hasSiblingMenus = root.hasSiblingMenus
 
+            root.subMenuLoader.menuLoaded.connect(function() {
+                root.subMenuLoader.menu.setParentWindow(root.parent.Window.window)
+            })
+
             root.subMenuLoader.handleMenuItem.connect(function(itemId) {
                 Qt.callLater(root.handleMenuItem, itemId)
                 root.subMenuLoader.close()

--- a/framework/uicomponents/view/popupview.cpp
+++ b/framework/uicomponents/view/popupview.cpp
@@ -856,7 +856,7 @@ void PopupView::resolveNavigationParentControl()
             setNavigationParentControl(nullptr);
         });
 
-        setParentWindow(ctrl->window());
+        // setParentWindow(ctrl->window());
     }
 }
 


### PR DESCRIPTION
Helper branch in investigation of https://github.com/audacity/audacity/issues/8521, i.e., menu child of a pop-up window appears behind the said window:
![image](https://github.com/user-attachments/assets/f1a315a3-2bc9-48d2-8868-e0dddc236b4f)

deb2fd5804af1d408ea13875e655a0247bff03d3 fixes the problem partly:
![image](https://github.com/user-attachments/assets/e090707b-74cd-4038-81d3-b17d4eba2ec5)

deb2fd5804af1d408ea13875e655a0247bff03d3 fixes the whole problem:
![image](https://github.com/user-attachments/assets/9e2a71d5-1947-4b35-ab26-7f11a35db66b)