### PR TITLE
adding FindWrapOpenGL.cmake file for local build fixes if using Xcode 26

### DIFF
--- a/buildscripts/cmake/FindWrapOpenGL.cmake
+++ b/buildscripts/cmake/FindWrapOpenGL.cmake
@@ -1,0 +1,71 @@
+###############################################################################
+# Copied from Qt 6.9.1 for macOS
+# Removed references to the AGL framework, which has been removed in macOS 26.0
+###############################################################################
+
+# Copyright (C) 2022 The Qt Company Ltd.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# We can't create the same interface imported target multiple times, CMake will complain if we do
+# that. This can happen if the find_package call is done in multiple different subdirectories.
+if(TARGET WrapOpenGL::WrapOpenGL)
+    set(WrapOpenGL_FOUND ON)
+    return()
+endif()
+
+set(WrapOpenGL_FOUND OFF)
+
+find_package(OpenGL ${WrapOpenGL_FIND_VERSION})
+
+if (OpenGL_FOUND)
+    set(WrapOpenGL_FOUND ON)
+
+    add_library(WrapOpenGL::WrapOpenGL INTERFACE IMPORTED)
+    if(APPLE)
+        # CMake 3.27 and older:
+        # On Darwin platforms FindOpenGL sets IMPORTED_LOCATION to the absolute path of the library
+        # within the framework. This ends up as an absolute path link flag, which we don't want,
+        # because that makes our .prl files un-relocatable.
+        # Extract the framework path instead, and use that in INTERFACE_LINK_LIBRARIES,
+        # which CMake ends up transforming into a relocatable -framework flag.
+        # See https://gitlab.kitware.com/cmake/cmake/-/issues/20871 for details.
+        #
+        # CMake 3.28 and above:
+        # IMPORTED_LOCATION is the absolute path the the OpenGL.framework folder.
+        get_target_property(__opengl_fw_lib_path OpenGL::GL IMPORTED_LOCATION)
+        if(__opengl_fw_lib_path AND NOT __opengl_fw_lib_path MATCHES "/([^/]+)\\.framework$")
+            get_filename_component(__opengl_fw_path "${__opengl_fw_lib_path}" DIRECTORY)
+        endif()
+
+        if(NOT __opengl_fw_path)
+            # Just a safety measure in case if no OpenGL::GL target exists.
+            set(__opengl_fw_path "-framework OpenGL")
+        endif()
+
+        # find_library(WrapOpenGL_AGL NAMES AGL)
+        # if(WrapOpenGL_AGL)
+        #     set(__opengl_agl_fw_path "${WrapOpenGL_AGL}")
+        # endif()
+        # if(NOT __opengl_agl_fw_path)
+        #     set(__opengl_agl_fw_path "-framework AGL")
+        # endif()
+
+        target_link_libraries(WrapOpenGL::WrapOpenGL INTERFACE ${__opengl_fw_path})
+        # target_link_libraries(WrapOpenGL::WrapOpenGL INTERFACE ${__opengl_agl_fw_path})
+    else()
+        target_link_libraries(WrapOpenGL::WrapOpenGL INTERFACE OpenGL::GL)
+    endif()
+elseif(UNIX AND NOT APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "Integrity")
+    # Requesting only the OpenGL component ensures CMake does not mark the package as
+    # not found if neither GLX nor libGL are available. This allows finding OpenGL
+    # on an X11-less Linux system.
+    find_package(OpenGL ${WrapOpenGL_FIND_VERSION} COMPONENTS OpenGL)
+    if (OpenGL_FOUND)
+        set(WrapOpenGL_FOUND ON)
+        add_library(WrapOpenGL::WrapOpenGL INTERFACE IMPORTED)
+        target_link_libraries(WrapOpenGL::WrapOpenGL INTERFACE OpenGL::OpenGL)
+    endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(WrapOpenGL DEFAULT_MSG WrapOpenGL_FOUND)


### PR DESCRIPTION
for local build only for now we want to make sure macOS 26 build are working so we add the `FindWrapOpenGL.cmake` file 